### PR TITLE
Update the SideBar to reflect User Authentications tatus

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -21,7 +21,7 @@ const teamMembers: TeamMember[] = [
     name: 'Vincent Bui',
     github: 'https://github.com/VincentBui0',
     linkedin: 'https://www.linkedin.com/in/vincent-bui0',
-    imageName: 'vincent.jpg',
+    imageName: 'Vincent.jpg',
   },
   {
     name: 'David Eastmond',

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,8 +1,8 @@
 'use client';
 import { useAuth } from '@/hooks/useAuth';
 import { GitHubAvatar } from '../githubAvatar/GitHubAvatar';
+import SidebarIcon from './SidebarIcon';
 import SidebarItem from './SidebarItem';
-
 export default function Sidebar() {
   const { user, signOut, signIn, isAuthenticated } = useAuth();
 
@@ -26,7 +26,7 @@ export default function Sidebar() {
           {isAuthenticated ? (
             <AuthenticatedSidebarItems signOut={signOut} />
           ) : (
-            <AuthButton action={signIn} label="Sign in" />
+            <AuthButton action={signIn} label="Sign In" />
           )}
         </div>
       </ul>
@@ -41,7 +41,7 @@ const AuthenticatedSidebarItems = ({ signOut }: { signOut: () => void }) => {
       <SidebarItem label="Contributors" />
       <SidebarItem label="Reviews" />
       <SidebarItem label="Quality" />
-      <AuthButton action={signOut} label="Sign out" />
+      <AuthButton action={signOut} label="Sign Out" />
     </>
   );
 };
@@ -51,11 +51,12 @@ const AuthButton = ({
   label,
 }: {
   action: () => void;
-  label: string;
+  label: 'Sign In' | 'Sign Out';
 }) => {
   return (
     <li>
-      <button className="w-full justify-end" onClick={action}>
+      <button className="w-full justify-between" onClick={action}>
+        <SidebarIcon label={label} />
         {label}
       </button>
     </li>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -24,7 +24,13 @@ export default function Sidebar() {
         <div className="flex flex-col gap-1 font-semibold text-lg">
           <SidebarItem label="Home" />
           {isAuthenticated ? (
-            <AuthenticatedSidebarItems signOut={signOut} />
+            <>
+              <SidebarItem label="Commits" />
+              <SidebarItem label="Contributors" />
+              <SidebarItem label="Reviews" />
+              <SidebarItem label="Quality" />
+              <AuthButton action={signOut} label="Sign Out" />
+            </>
           ) : (
             <AuthButton action={signIn} label="Sign In" />
           )}
@@ -33,18 +39,6 @@ export default function Sidebar() {
     </div>
   );
 }
-
-const AuthenticatedSidebarItems = ({ signOut }: { signOut: () => void }) => {
-  return (
-    <>
-      <SidebarItem label="Commits" />
-      <SidebarItem label="Contributors" />
-      <SidebarItem label="Reviews" />
-      <SidebarItem label="Quality" />
-      <AuthButton action={signOut} label="Sign Out" />
-    </>
-  );
-};
 
 const AuthButton = ({
   action,

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,11 @@
-import ProfileIcon from '../icons/ProfileIcon';
+'use client';
+import { useAuth } from '@/hooks/useAuth';
+import { GitHubAvatar } from '../githubAvatar/GitHubAvatar';
 import SidebarItem from './SidebarItem';
 
 export default function Sidebar() {
+  const { user, signOut, signIn, isAuthenticated } = useAuth();
+
   return (
     <div className="drawer-side">
       <label
@@ -9,19 +13,51 @@ export default function Sidebar() {
         aria-label="close sidebar"
         className="drawer-overlay"
       ></label>
-      <ul className="menu text-base-content min-h-full w-60 p-4 ">
-        <div className="flex items-center gap-2 mb-4 justify-between text-2xl px-3 font-bold">
-          <ProfileIcon />
-          Jane Doe
-        </div>
+      <ul className="menu text-base-content min-h-full w-60 p-4 bg-base-100">
+        {isAuthenticated && (
+          <div className="flex items-center gap-2 mb-4 justify-between text-2xl px-3 font-bold">
+            <GitHubAvatar url={user.image!} />
+            {user?.name}
+          </div>
+        )}
+
         <div className="flex flex-col gap-1 font-semibold text-lg">
           <SidebarItem label="Home" />
-          <SidebarItem label="Commits" />
-          <SidebarItem label="Contributors" />
-          <SidebarItem label="Reviews" />
-          <SidebarItem label="Quality" />
+          {isAuthenticated ? (
+            <AuthenticatedSidebarItems signOut={signOut} />
+          ) : (
+            <AuthButton action={signIn} label="Sign in" />
+          )}
         </div>
       </ul>
     </div>
   );
 }
+
+const AuthenticatedSidebarItems = ({ signOut }: { signOut: () => void }) => {
+  return (
+    <>
+      <SidebarItem label="Commits" />
+      <SidebarItem label="Contributors" />
+      <SidebarItem label="Reviews" />
+      <SidebarItem label="Quality" />
+      <AuthButton action={signOut} label="Sign out" />
+    </>
+  );
+};
+
+const AuthButton = ({
+  action,
+  label,
+}: {
+  action: () => void;
+  label: string;
+}) => {
+  return (
+    <li>
+      <button className="w-full justify-end" onClick={action}>
+        {label}
+      </button>
+    </li>
+  );
+};

--- a/src/components/Sidebar/SidebarIcon.tsx
+++ b/src/components/Sidebar/SidebarIcon.tsx
@@ -2,6 +2,8 @@ import CommitIcon from '../icons/CommitIcon';
 import ContributorIcon from '../icons/ContributorIcon';
 import QualityIcon from '../icons/QualityIcon';
 import ReviewIcon from '../icons/ReviewIcon';
+import SignInIcon from '../icons/SignInIcon';
+import SignOutIcon from '../icons/SignOutIcon';
 import HomeIcon from './HomeIcon';
 
 const icons = {
@@ -10,6 +12,8 @@ const icons = {
   Contributors: <ContributorIcon />,
   Reviews: <ReviewIcon />,
   Quality: <QualityIcon />,
+  'Sign In': <SignInIcon />,
+  'Sign Out': <SignOutIcon />,
 } as const;
 
 type IconLabel = keyof typeof icons;

--- a/src/components/icons/SignInIcon.tsx
+++ b/src/components/icons/SignInIcon.tsx
@@ -1,0 +1,17 @@
+export default function SignInIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M10 16L12.59 13.41L9.17 10H20V8H9.17L12.59 4.59L10 2L4 8L10 16Z"
+        fill="currentColor"
+      />
+      <path d="M20 20H4V18H20V20Z" fill="currentColor" />
+    </svg>
+  );
+}

--- a/src/components/icons/SignOutIcon.tsx
+++ b/src/components/icons/SignOutIcon.tsx
@@ -1,0 +1,14 @@
+export default function SignInIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M14 16L18 12L14 8V11H4V13H14V16Z" fill="currentColor" />
+      <path d="M20 20H4V18H20V20Z" fill="currentColor" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Description

Addresses #MGF-48

<!-- Please include a summary of the change and which issue it addresses -->
- Fixes broken image link with one of the Jpgs
- Sign in and Signout functionality on the sidebar
- User name and avatar displays in sidebar
- menu items are hidden depending on auth status.
- Fixed transparency issue with sidebar 

<!-- Add relevant motivation and context -->
<!-- List any dependencies required for this change -->

Addresses: [ECG-#](https://dsd-east-coast-goats.atlassian.net/browse/ECG-#)

## Type of change

<!-- Please check the relevant options -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- Please check all items that apply -->

- [X] I have performed a self-review of my code
- [ ] I have added comments to complex code sections
- [ ] I have updated the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots

<!-- Please add screenshots if applicable -->
<!-- For UI changes, include before/after screenshots if possible -->
<!-- Specify OS, browser, and other relevant details for each screenshot -->

- Authenticated, small screen, menu
<img width="732" height="741" alt="image" src="https://github.com/user-attachments/assets/c847bfcf-d524-496e-8e65-5f72a9849eb0" />

- Not authenticated, small screen
<img width="734" height="866" alt="image" src="https://github.com/user-attachments/assets/352efd8b-72c1-4a8e-97e9-17089d4336ca" />

## Environment tested

<!-- Please specify OS, browser, and other relevant details -->

Tested on
- Edge, Firefox, Windows 11
## Additional context

<!-- Add any other context about the PR here -->
