### PR TITLE
Move client stuff out of root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,8 @@
-'use client';
-
 import Sidebar from '@/components/Sidebar/Sidebar';
 import Header from '@/components/Header';
-import HamburgerIcon from '@/components/icons/HamburgerIcon';
-import { lazy, Suspense, useRef } from 'react';
+import LazyFooter from '@/components/LazyFooter';
+import FloatingSidebarButton from '@/components/Sidebar/FloatingSidebarButton';
+
 import './globals.css';
 
 if (
@@ -14,42 +13,40 @@ if (
   require('../mocks');
 }
 
-const Footer = lazy(() => import('@/components/Footer'));
-
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const sidebarCheckboxId = 'my-drawer' as const;
-  const sidebarRef = useRef<HTMLInputElement>(null);
+  const sidebarCheckboxId = 'sidebar-checkbox' as const;
+
+  // Breakpoints must match to ensure users always have a way to access the sidebar
+  // Large screens: persistent sidebar (no sidebar button)
+  // Small screens: hidden sidebar + floating sidebar button
+  const showSidebar = 'lg:drawer-open' as const;
+  const hideFloatingButton = 'lg:hidden' as const;
 
   return (
     <html lang="en" className="h-screen">
-      <body className="drawer lg:drawer-open h-screen bg-base-300">
+      <body className={`drawer ${showSidebar} h-screen bg-base-300`}>
         <input
           id={sidebarCheckboxId}
           type="checkbox"
           className="drawer-toggle"
-          ref={sidebarRef}
         />
         <Sidebar checkboxId={sidebarCheckboxId} />
         <div className="drawer-content h-screen overflow-y-auto">
-          <div className="fab lg:hidden">
-            <button
-              className="btn btn-lg btn-circle btn-primary"
-              onClick={() => sidebarRef.current?.click()}
-            >
-              <HamburgerIcon />
-            </button>
-          </div>
+          <FloatingSidebarButton
+            checkboxId={sidebarCheckboxId}
+            buttonClass={hideFloatingButton}
+          />
+
           <div className="h-screen flex flex-col">
             <Header />
             <main className="flex-grow px-4 pb-4">{children}</main>
           </div>
-          <Suspense fallback={null}>
-            <Footer />
-          </Suspense>
+
+          <LazyFooter />
         </div>
       </body>
     </html>

--- a/src/components/LazyFooter.tsx
+++ b/src/components/LazyFooter.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { lazy, Suspense } from 'react';
+
+const Footer = lazy(() => import('@/components/Footer'));
+
+export default function LazyFooter() {
+  return (
+    <Suspense fallback={null}>
+      <Footer />
+    </Suspense>
+  );
+}

--- a/src/components/Sidebar/FloatingSidebarButton.tsx
+++ b/src/components/Sidebar/FloatingSidebarButton.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import HamburgerIcon from '@/components/icons/HamburgerIcon';
+import { useRef } from 'react';
+
+export default function FloatingSidebarButton({
+  buttonClass,
+  checkboxId,
+}: {
+  buttonClass: string;
+  checkboxId: string;
+}) {
+  const ref = useRef<HTMLLabelElement>(null);
+
+  return (
+    <>
+      <label
+        htmlFor={checkboxId}
+        className="drawer-button hidden"
+        ref={ref}
+      ></label>
+      <div className={`fab ${buttonClass}`}>
+        <button
+          className="btn btn-lg btn-circle btn-primary"
+          onClick={() => ref.current?.click()}
+        >
+          <HamburgerIcon />
+        </button>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
- Add LazyFooter wrapper component
- Use a label ref instead of checkbox ref to implement the floating sidebar button
- Remove 'use client' from root layout.
- Add some comments about breakpoint classes