### PR TITLE
[MGF-64]: Add avg time to first review widget

### DIFF
--- a/src/app/api/users/[user_id]/repos/route.ts
+++ b/src/app/api/users/[user_id]/repos/route.ts
@@ -7,6 +7,7 @@ import { createUserRepoValidator } from '@/lib/validators/createUserRepoValidato
 import { and, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
+import { getGithubRepoIdsForUser } from '@/lib/db/getGithubRepoIdsForUser';
 
 export async function POST(
   req: NextRequest,
@@ -71,14 +72,7 @@ export async function GET(
     }
 
     const { user_id } = await params;
-
-    const userRepos = await db
-      .select({
-        githubRepoId: repo.githubRepoId,
-      })
-      .from(userRepo)
-      .where(eq(userRepo.userId, user_id))
-      .innerJoin(repo, eq(userRepo.repoId, repo.id));
+    const userRepos = await getGithubRepoIdsForUser(user_id);
 
     // Create a github API
     const api = await createApi();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
 import StatsCard from '@/components/StatsCard/StatsCard';
+import AvgTimeToFirstReview from '@/components/AvgTimeToFirstReview/AvgTimeToFirstReview';
+import { Suspense } from 'react';
 
 export default function HomePage() {
   return (
@@ -34,11 +36,17 @@ export default function HomePage() {
       >
         <StatsCard title="Open PRs" value="24" />
         <StatsCard title="Avg Reviews Per PR" value="2.3" />
-        <StatsCard
-          title="Avg Time To First Review"
-          subtitle="Last 30 days"
-          value="4.2h"
-        />
+        <Suspense
+          fallback={
+            <StatsCard
+              title="Avg Time to First Review"
+              value=""
+              isBusy={true}
+            />
+          }
+        >
+          <AvgTimeToFirstReview />
+        </Suspense>
         <StatsCard title="Avg Time To Merge" value="18.5h" />
       </aside>
     </div>

--- a/src/components/AvgTimeToFirstReview/AvgTimeToFirstReview.tsx
+++ b/src/components/AvgTimeToFirstReview/AvgTimeToFirstReview.tsx
@@ -1,0 +1,26 @@
+import { getServerSession } from '@/lib/auth/getServerSession';
+import StatsCard from '@/components/StatsCard/StatsCard';
+import { getAvgTimeToFirstReview } from '@/components/AvgTimeToFirstReview/getAvgTimeToFirstReview';
+
+
+
+export default async function AvgTimeToFirstReview() {
+  const title = 'Avg Time to First Review' as const;
+  const fallback = <StatsCard title={title} value="?" />;
+
+  const { isAuthenticated, user } = await getServerSession();
+  if (!isAuthenticated || !user) {
+    return fallback;
+  }
+
+  try {
+    const value = await getAvgTimeToFirstReview(user.id);
+    return <StatsCard title={title} value={value} />;
+  } catch (error) {
+    console.warn(
+      'Error fetching review metrics:',
+      error instanceof Error ? error.message : error
+    );
+    return fallback;
+  }
+}

--- a/src/components/AvgTimeToFirstReview/getAvgTimeToFirstReview.ts
+++ b/src/components/AvgTimeToFirstReview/getAvgTimeToFirstReview.ts
@@ -1,0 +1,48 @@
+import { getReviewData } from '@/components/AvgTimeToFirstReview/getReviewData';
+
+function formatTime(seconds: number): string {
+  const minutes = seconds / 60;
+  const hours = seconds / 3600;
+  const days = hours / 24;
+
+  if (days > 3) {
+    return '+3d';
+  }
+  if (days >= 1) {
+    return `${days.toFixed(1)}d`;
+  }
+  if (hours >= 1) {
+    return `${hours.toFixed(1)}h`;
+  }
+  return `${minutes.toFixed(1)}m`;
+}
+
+function calculateAvgTimeToFirstReview(
+  data: {
+    pullRequestCreatedAt: string;
+    reviewSubmittedAt: string;
+  }[]
+): number {
+  if (data.length === 0) {
+    return 0;
+  }
+
+  const totalSeconds = data.reduce((sum, item) => {
+    const createdAt = new Date(item.pullRequestCreatedAt);
+    const submittedAt = new Date(item.reviewSubmittedAt);
+    const diffMs = submittedAt.getTime() - createdAt.getTime();
+    const diffSeconds = diffMs / 1000;
+    return sum + diffSeconds;
+  }, 0);
+
+  return Math.ceil(totalSeconds / data.length);
+}
+
+export async function getAvgTimeToFirstReview(userId: string): Promise<string> {
+  try {
+    const data = await getReviewData(userId);
+    return formatTime(calculateAvgTimeToFirstReview(data));
+  } catch {
+    return '--';
+  }
+}

--- a/src/components/AvgTimeToFirstReview/getReviewData.ts
+++ b/src/components/AvgTimeToFirstReview/getReviewData.ts
@@ -1,0 +1,73 @@
+import { getGithubRepoIdsForUser } from '@/lib/db/getGithubRepoIdsForUser';
+import { createApi } from '@/lib/github/server';
+import { avgTimeToFirstReview } from '@/mocks/data/avgTimeToFirstReview';
+
+type ReviewData = {
+  repoName: string;
+  repoOwner: string;
+  pullRequestNumber: number;
+  pullRequestCreatedAt: string;
+  reviewSubmittedAt: string;
+};
+
+// Get user's repos from database (repo ids)
+// For each repo:
+//   1. Fetch repo details
+//   2. Fetch PRs from last 30 days (PR number and created_at)
+//   3. For each PR, fetch reviews (limit = 1)
+//   4. "save" the time from PR creation to first review
+
+export async function getReviewData(userId: string): Promise<ReviewData[]> {
+  // FIXME: not the best way to handle mock data
+  if (process.env.NODE_ENV !== 'production') {
+    return avgTimeToFirstReview;
+  }
+  const api = await createApi();
+
+  // Get user's repos from database (repo ids)
+  const userRepos = await getGithubRepoIdsForUser(userId);
+  const data = [] as ReviewData[];
+
+  // For each repo:
+  for (const userRepo of userRepos) {
+    // 1. Fetch repo details
+    const repoResponse = await api.getRepoById(userRepo.githubRepoId);
+    const owner = repoResponse.owner.login;
+    const repo = repoResponse.name;
+
+    //   2. Fetch PRs from last 30 days (PR number and created_at)
+    const pullRequests = await api.getPullRequestsForRepo({
+      owner,
+      repo,
+      state: 'all',
+      per_page: 100,
+    }); // TODO: additional pages of pull requests
+
+    //   3. For each PR, fetch reviews (limit = 1)
+    for (const pullRequest of pullRequests) {
+      const reviewsResponse = await api.getReviewsForPullRequest({
+        owner,
+        repo,
+        pull_number: pullRequest.number,
+        per_page: 1,
+      });
+
+      if (reviewsResponse.length > 0) {
+        const submittedAt = reviewsResponse[0].submitted_at;
+
+        if (submittedAt) {
+          //   4. "save" the time from PR creation to first review
+          data.push({
+            repoOwner: owner,
+            repoName: repo,
+            pullRequestCreatedAt: pullRequest.created_at,
+            pullRequestNumber: pullRequest.number,
+            reviewSubmittedAt: submittedAt,
+          });
+        }
+      }
+    }
+  }
+
+  return data;
+}

--- a/src/lib/db/getGithubRepoIdsForUser.ts
+++ b/src/lib/db/getGithubRepoIdsForUser.ts
@@ -1,0 +1,13 @@
+import { db } from '@/db';
+import { userRepo, repo } from '@/db/schema';
+import { eq } from 'drizzle-orm';
+
+export async function getGithubRepoIdsForUser(userId: string) {
+  return db
+    .select({
+      githubRepoId: repo.githubRepoId,
+    })
+    .from(userRepo)
+    .where(eq(userRepo.userId, userId))
+    .innerJoin(repo, eq(userRepo.repoId, repo.id));
+}

--- a/src/lib/github/apiHandlers.ts
+++ b/src/lib/github/apiHandlers.ts
@@ -21,13 +21,17 @@ export const apiHandlers = (
     owner,
     repo,
     state,
+    page = 1,
+    per_page = 10,
   }: {
     owner: string;
     repo: string;
-    state: 'open' | 'closed';
+    state: 'open' | 'closed' | 'all';
+    page?: number;
+    per_page?: number;
   }) =>
     requestHandler<GitHubPullRequest[]>(
-      `/repos/${owner}/${repo}/pulls?state=${state}`
+      `/repos/${owner}/${repo}/pulls?state=${state}&sort=created&direction=desc&per_page=${per_page}&page=${page}`
     ),
 
   getContributorsForRepo: ({ owner, repo }: { owner: string; repo: string }) =>
@@ -40,13 +44,15 @@ export const apiHandlers = (
     owner,
     repo,
     pull_number,
+    per_page = 30,
   }: {
     owner: string;
     repo: string;
     pull_number: number;
+    per_page?: number;
   }) =>
     requestHandler<GitHubPullRequestReview[]>(
-      `/repos/${owner}/${repo}/pulls/${pull_number}/reviews`
+      `/repos/${owner}/${repo}/pulls/${pull_number}/reviews?per_page=${per_page}`
     ),
 
   graphqlExample: (query: string) =>

--- a/src/lib/github/handleClientRequest.ts
+++ b/src/lib/github/handleClientRequest.ts
@@ -6,7 +6,7 @@ import { fetchRequest } from '@/lib/request';
 export async function handleClientRequest<T>(
   url: string,
   body?: Record<string, string>
-): Promise<Result<T>> {
+): Promise<T> {
   const baseUrl =
     `${process.env.NEXT_PUBLIC_BASE_URL}${githubApiPath}` as const;
 

--- a/src/lib/github/handleServerRequest.ts
+++ b/src/lib/github/handleServerRequest.ts
@@ -7,7 +7,7 @@ import { fetchRequest } from '@/lib/request';
 export async function handleServerRequest<T>(
   url: string,
   body?: Record<string, string>
-): Promise<Result<T>> {
+): Promise<T> {
   const bearerToken = await getBearerAccessToken();
 
   if (!bearerToken) {

--- a/src/mocks/data/avgTimeToFirstReview.ts
+++ b/src/mocks/data/avgTimeToFirstReview.ts
@@ -1,0 +1,261 @@
+export const avgTimeToFirstReview = [
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-10-03T20:27:32Z',
+    pullRequestNumber: 58,
+    reviewSubmittedAt: '2025-10-03T21:16:19Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-10-03T15:36:36Z',
+    pullRequestNumber: 56,
+    reviewSubmittedAt: '2025-10-03T22:50:05Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-10-02T18:40:25Z',
+    pullRequestNumber: 55,
+    reviewSubmittedAt: '2025-10-03T00:20:10Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-10-02T17:19:09Z',
+    pullRequestNumber: 54,
+    reviewSubmittedAt: '2025-10-02T17:22:48Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-10-02T01:44:55Z',
+    pullRequestNumber: 53,
+    reviewSubmittedAt: '2025-10-02T13:13:36Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-10-01T20:41:32Z',
+    pullRequestNumber: 51,
+    reviewSubmittedAt: '2025-10-01T21:56:24Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-30T23:04:04Z',
+    pullRequestNumber: 50,
+    reviewSubmittedAt: '2025-10-01T18:04:10Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-30T21:58:59Z',
+    pullRequestNumber: 49,
+    reviewSubmittedAt: '2025-09-30T22:29:52Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-29T23:07:43Z',
+    pullRequestNumber: 47,
+    reviewSubmittedAt: '2025-09-30T12:48:18Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-29T22:29:16Z',
+    pullRequestNumber: 46,
+    reviewSubmittedAt: '2025-09-30T11:17:50Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-28T18:18:50Z',
+    pullRequestNumber: 45,
+    reviewSubmittedAt: '2025-09-30T14:35:55Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-28T17:14:16Z',
+    pullRequestNumber: 44,
+    reviewSubmittedAt: '2025-09-28T18:52:42Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-27T23:27:29Z',
+    pullRequestNumber: 43,
+    reviewSubmittedAt: '2025-09-27T23:45:06Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-27T15:20:34Z',
+    pullRequestNumber: 42,
+    reviewSubmittedAt: '2025-09-29T19:51:03Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-27T00:45:42Z',
+    pullRequestNumber: 41,
+    reviewSubmittedAt: '2025-09-27T20:16:00Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-26T14:31:35Z',
+    pullRequestNumber: 40,
+    reviewSubmittedAt: '2025-09-26T15:10:27Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-25T21:37:54Z',
+    pullRequestNumber: 39,
+    reviewSubmittedAt: '2025-09-25T21:56:06Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-25T01:23:45Z',
+    pullRequestNumber: 38,
+    reviewSubmittedAt: '2025-09-25T21:38:35Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-24T21:46:19Z',
+    pullRequestNumber: 37,
+    reviewSubmittedAt: '2025-09-24T22:50:28Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-19T18:30:17Z',
+    pullRequestNumber: 34,
+    reviewSubmittedAt: '2025-09-23T20:39:07Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-17T20:56:18Z',
+    pullRequestNumber: 33,
+    reviewSubmittedAt: '2025-09-17T21:20:58Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-16T20:32:46Z',
+    pullRequestNumber: 32,
+    reviewSubmittedAt: '2025-09-16T20:48:09Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-16T18:18:29Z',
+    pullRequestNumber: 31,
+    reviewSubmittedAt: '2025-09-20T18:32:29Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-16T04:37:27Z',
+    pullRequestNumber: 30,
+    reviewSubmittedAt: '2025-09-16T17:48:51Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-15T21:58:55Z',
+    pullRequestNumber: 29,
+    reviewSubmittedAt: '2025-09-16T18:04:27Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-15T13:58:53Z',
+    pullRequestNumber: 28,
+    reviewSubmittedAt: '2025-09-15T15:44:58Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-13T17:33:42Z',
+    pullRequestNumber: 27,
+    reviewSubmittedAt: '2025-09-14T22:17:24Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-13T04:06:50Z',
+    pullRequestNumber: 26,
+    reviewSubmittedAt: '2025-09-13T11:28:56Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-11T23:36:14Z',
+    pullRequestNumber: 24,
+    reviewSubmittedAt: '2025-09-12T12:44:21Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-11T15:58:37Z',
+    pullRequestNumber: 23,
+    reviewSubmittedAt: '2025-09-11T16:58:45Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-08T21:39:02Z',
+    pullRequestNumber: 21,
+    reviewSubmittedAt: '2025-09-08T21:41:50Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-05T21:36:57Z',
+    pullRequestNumber: 20,
+    reviewSubmittedAt: '2025-09-05T21:38:35Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-05T16:05:09Z',
+    pullRequestNumber: 19,
+    reviewSubmittedAt: '2025-09-05T16:14:37Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-05T13:10:57Z',
+    pullRequestNumber: 18,
+    reviewSubmittedAt: '2025-09-05T13:52:27Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-05T12:48:24Z',
+    pullRequestNumber: 17,
+    reviewSubmittedAt: '2025-09-05T14:18:04Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-04T21:23:43Z',
+    pullRequestNumber: 16,
+    reviewSubmittedAt: '2025-09-04T21:29:56Z'
+  },
+  {
+    repoOwner: 'chingu-voyages',
+    repoName: 'V57-tier3-team-36',
+    pullRequestCreatedAt: '2025-09-04T18:36:03Z',
+    pullRequestNumber: 15,
+    reviewSubmittedAt: '2025-09-04T19:44:51Z'
+  }
+];

--- a/src/tests/getAvgTimeToFirstReview.test.ts
+++ b/src/tests/getAvgTimeToFirstReview.test.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+import { getAvgTimeToFirstReview } from '@/components/AvgTimeToFirstReview/getAvgTimeToFirstReview';
+
+test('getAvgTimeToFirstReview', async () => {
+  expect(await getAvgTimeToFirstReview('')).toEqual('13.4h');
+});


### PR DESCRIPTION
This calculation makes a whole lot of requests, and this solution doesn't even fetch multiple pages. We should consider not including this feature.

Widget alternatives:

- Average time to first review (only open PRs)
- Average time open (age of open PRs)
- Number/percent of Draft PRs
- Number/percent of non-draft (ready) PRs
- Number/percent stale PRs (no activity in X days)
- Number/percent unreviewed PRs (no reviews yet)
- Average PR size (lines/files changed)
- Number/percent approved PRs (ready-to-deploy) PRs