### PR TITLE
fix: change the add repo modal button to reflect whether repo is in u…

### DIFF
--- a/src/components/AddRepoModal/RepoSearchResultCard.tsx
+++ b/src/components/AddRepoModal/RepoSearchResultCard.tsx
@@ -36,8 +36,8 @@ export function RepoSearchResultCard({
                 className="btn btn-success"
                 onClick={() => removeRepo?.(id!.toString())}
               >
-                <span className="block group-hover:hidden">Selected</span>
-                <span className="hidden group-hover:block">Deselect</span>
+                <span className="block group-hover:hidden">Added</span>
+                <span className="hidden group-hover:block">Remove</span>
               </button>
             </div>
           ) : (
@@ -45,7 +45,7 @@ export function RepoSearchResultCard({
               className="btn btn-primary"
               onClick={() => addRepo?.(id!.toString())}
             >
-              + Select
+              + Add
             </button>
           )}
         </div>

--- a/src/components/AddRepoModal/RepoSearchResultCard.tsx
+++ b/src/components/AddRepoModal/RepoSearchResultCard.tsx
@@ -13,7 +13,9 @@ export function RepoSearchResultCard({
   description: string | null;
   url: string;
 }) {
-  const { addRepo, removeRepo, isLoadingRepos, selectedRepo } = useAppContext();
+  const { addRepo, removeRepo, isLoadingRepos, repos } = useAppContext();
+
+  const isAdded = repos?.some(repo => repo.id === id);
 
   return (
     <div className="card card-border bg-base-100">
@@ -28,7 +30,7 @@ export function RepoSearchResultCard({
             <button className="btn btn-disabled">
               <span className="loading loading-dots" />
             </button>
-          ) : selectedRepo?.id === id ? (
+          ) : isAdded ? (
             <div className="group">
               <button
                 className="btn btn-success"

--- a/src/components/PRSearchbar/PRSearchbar.tsx
+++ b/src/components/PRSearchbar/PRSearchbar.tsx
@@ -42,7 +42,12 @@ export default function PRSearchbar({
           className="grow"
           placeholder="Search"
           onChange={e => setInputValue(e.target.value)}
-          onSubmit={e => onSearch(inputValue)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              onSearch(inputValue);
+            }
+          }}
         />
       </label>
       <PRFilter filters={filters} setFilters={setFilters} />


### PR DESCRIPTION
## Description
Previously, the buttons for the add repo modal didn't correctly check if the repo was already in the list of user repos.
Now, it will correctly check them and be shown as "Added" and on hover, "Remove".

Addresses: [ECG-#](https://dsd-east-coast-goats.atlassian.net/browse/ECG-#)

## Type of change

<!-- Please check the relevant options -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- Please check all items that apply -->

- [ ] I have performed a self-review of my code
- [ ] I have added comments to complex code sections
- [ ] I have updated the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots

<!-- Please add screenshots if applicable -->
<!-- For UI changes, include before/after screenshots if possible -->
<!-- Specify OS, browser, and other relevant details for each screenshot -->

## Environment tested

<!-- Please specify OS, browser, and other relevant details -->

- OS: [e.g. macOS, Windows]
- Browser: [e.g. Chrome, Firefox, Safari]

## Additional context

<!-- Add any other context about the PR here -->
